### PR TITLE
Add modern hero and font

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -6,11 +6,13 @@ import PostList from '@/components/PostList';
 import TrendingConcerts from '@/components/server/TrendingConcerts';
 import AddPostClientWrapper from '@/components/AddPostClientWrapper';
 import Navbar from '@/components/Navbar'; // ✅ Navbar import edildi
+import HeroSection from '@/components/HeroSection';
 
 export default function HomePage() {
     return (
         <>
             <Navbar /> {/* ✅ Navbar en üste yerleştirildi */}
+            <HeroSection />
 
             <Box sx={{ px: 4, py: 3 }}>
                 <TrendingConcerts />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import Providers from './providers';
+import { Inter } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'], display: 'swap' });
 
 export const metadata: Metadata = {
   title: 'Concertly',
@@ -9,7 +12,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className={inter.className}>
       <body>
         <Providers>{children}</Providers>
       </body>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,32 @@
+import { Box, Typography, Button } from '@mui/material';
+import Link from 'next/link';
+
+export default function HeroSection() {
+    return (
+        <Box
+            sx={{
+                minHeight: '40vh',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                textAlign: 'center',
+                color: 'common.white',
+                background: 'linear-gradient(135deg, #7c3aed, #14b8a6)',
+                borderRadius: 2,
+                p: 4,
+                mb: 4,
+            }}
+        >
+            <Typography variant="h3" component="h1" gutterBottom sx={{ fontWeight: 'bold' }}>
+                Welcome to Concertly
+            </Typography>
+            <Typography variant="h6" sx={{ mb: 2, maxWidth: 600 }}>
+                Discover the hottest concerts and share your experiences with fellow fans.
+            </Typography>
+            <Button component={Link} href="/register" variant="contained" color="secondary">
+                Join Now
+            </Button>
+        </Box>
+    );
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -12,7 +12,7 @@ const theme = createTheme({
         },
     },
     typography: {
-        fontFamily: 'Roboto, sans-serif',
+        fontFamily: 'var(--font-inter), Inter, Roboto, sans-serif',
     },
 });
 


### PR DESCRIPTION
## Summary
- introduce a new HeroSection with gradient background and call-to-action
- display HeroSection on the home page
- load Inter font globally and use it in the MUI theme

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b3702da4832da83c2fdd1462c485